### PR TITLE
WIP: changes for cluster modules

### DIFF
--- a/apis/v1alpha3/zz_generated.conversion.go
+++ b/apis/v1alpha3/zz_generated.conversion.go
@@ -1680,5 +1680,6 @@ func autoConvert_v1beta1_VirtualMachineCloneSpec_To_v1alpha3_VirtualMachineClone
 	out.CustomVMXKeys = *(*map[string]string)(unsafe.Pointer(&in.CustomVMXKeys))
 	// WARNING: in.TagIDs requires manual conversion: does not exist in peer-type
 	// WARNING: in.PciDevices requires manual conversion: does not exist in peer-type
+	// WARNING: in.ClusterModuleID requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/apis/v1alpha4/zz_generated.conversion.go
+++ b/apis/v1alpha4/zz_generated.conversion.go
@@ -1798,5 +1798,6 @@ func autoConvert_v1beta1_VirtualMachineCloneSpec_To_v1alpha4_VirtualMachineClone
 	out.CustomVMXKeys = *(*map[string]string)(unsafe.Pointer(&in.CustomVMXKeys))
 	// WARNING: in.TagIDs requires manual conversion: does not exist in peer-type
 	// WARNING: in.PciDevices requires manual conversion: does not exist in peer-type
+	// WARNING: in.ClusterModuleID requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -154,6 +154,8 @@ type VirtualMachineCloneSpec struct {
 	// PciDevices is the list of pci devices used by the virtual machine.
 	// +optional
 	PciDevices []PCIDeviceSpec `json:"pciDevices,omitempty"`
+	// +optional
+	ClusterModuleID string `json:"clusterModuleID,omitempty"`
 }
 
 // VSphereMachineTemplateResource describes the data needed to create a VSphereMachine from a template

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -855,6 +855,8 @@ spec:
                   Defaults to LinkedClone, but fails gracefully to FullClone if the
                   source of the clone operation has no snapshots.
                 type: string
+              clusterModuleID:
+                type: string
               customVMXKeys:
                 additionalProperties:
                   type: string

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -748,6 +748,8 @@ spec:
                           but fails gracefully to FullClone if the source of the clone
                           operation has no snapshots.
                         type: string
+                      clusterModuleID:
+                        type: string
                       customVMXKeys:
                         additionalProperties:
                           type: string

--- a/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/config/default/crd/bases/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -917,6 +917,8 @@ spec:
                   Defaults to LinkedClone, but fails gracefully to FullClone if the
                   source of the clone operation has no snapshots.
                 type: string
+              clusterModuleID:
+                type: string
               customVMXKeys:
                 additionalProperties:
                   type: string

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmware/govmomi/pbm"
 	pbmTypes "github.com/vmware/govmomi/pbm/types"
 	"github.com/vmware/govmomi/property"
+	vapi "github.com/vmware/govmomi/vapi/cluster"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
@@ -119,6 +120,13 @@ func (vms *VMService) ReconcileVM(ctx *context.VMContext) (vm infrav1.VirtualMac
 	}
 
 	vms.reconcileUUID(vmCtx)
+
+	if module := ctx.VSphereVM.Spec.ClusterModuleID; module != "" {
+		_, err := addToClusterModule(ctx)
+		if err != nil {
+			return vm, err
+		}
+	}
 
 	if err := vms.reconcileNetworkStatus(vmCtx); err != nil {
 		return vm, err
@@ -535,4 +543,47 @@ func (vms *VMService) reconcileTags(ctx *virtualMachineContext) error {
 	}
 
 	return nil
+}
+
+func addToClusterModule(ctx *context.VMContext) (bool, error) {
+	//module := "52fa7c2d-f82f-e4f8-a06a-2d0bbf79d2a4"
+	module := ctx.VSphereVM.Spec.ClusterModuleID
+	ctx.Logger.Info("adding to cluster module with module ID: ", module)
+	//if module := ctx.VSphereVM.Spec.ClusterModuleID; module != "" {
+	vmRef, err := findVM(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	isMember, err := isMoRefModuleMember(ctx, module, vmRef)
+	if err != nil {
+		return false, err
+	}
+
+	if !isMember {
+		manager := vapi.NewManager(ctx.Session.TagManager.Client)
+		added, err := manager.AddModuleMembers(ctx, module, []mo.Reference{vmRef}...)
+		if !added {
+			return added, errors.Wrapf(err, "unable to add to cluster module")
+		}
+		return true, nil
+	}
+	//}
+	return false, nil
+}
+
+func isMoRefModuleMember(ctx *context.VMContext, moduleID string, moRef types.ManagedObjectReference) (bool, error) {
+	manager := vapi.NewManager(ctx.Session.TagManager.Client)
+	moduleMembers, err := manager.ListModuleMembers(ctx, moduleID)
+	if err != nil {
+		return false, err
+	}
+
+	for _, member := range moduleMembers {
+		if member.Reference() == moRef.Reference() {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Incorporate cluster modules for anti-affinity of nodes

This PR assumes that the user supplies a Cluster Module ID as part of the VSphereMachineTemplate (which is the same for all nodes of a Control plane & all nodes within a node pool). During VM creation, we make govmomi calls to add the VM reference to the Cluster module.