### PR TITLE
Refine VMG controller when generate per-MD zone labels

### DIFF
--- a/controllers/vmware/virtualmachinegroup_reconciler.go
+++ b/controllers/vmware/virtualmachinegroup_reconciler.go
@@ -448,13 +448,13 @@ func GenerateVMGPlacementLabels(ctx context.Context, vmg *vmoprv1.VirtualMachine
 			// TODO: Establish membership via the machine deployment name label
 			if strings.Contains(member.Name, md) {
 				// Get the VM placement information by member status.
-				// Legacy already-placed VM won't have Placement info, just skip it.
+				// VMs that have undergone placement do not have Placement info set, skip.
 				if member.Placement == nil {
 					log.V(4).Info("VM in VMG has no placement info. Placement is nil", "VM", member.Name, "VMG", vmg.Name, "Namespace", vmg.Namespace)
 					continue
 				}
 
-				// Skip and try next member if Zone is empty, alrough it should not happen after Placement is not nil.
+				// Skip to next member if Zone is empty.
 				zone := member.Placement.Zone
 				if zone == "" {
 					log.V(4).Info("VM in VMG has no placement info. Zone is empty", "VM", member.Name, "VMG", vmg.Name, "Namespace", vmg.Namespace)

--- a/controllers/vmware/virtualmachinegroup_reconciler.go
+++ b/controllers/vmware/virtualmachinegroup_reconciler.go
@@ -243,6 +243,9 @@ func (r *VirtualMachineGroupReconciler) createOrUpdateVMG(ctx context.Context, c
 		// Do not update per-md-zone label once set, as placement decision should not change without user explicitly
 		// ask.
 		placementDecisionLabels, err := GenerateVMGPlacementLabels(ctx, desiredVMG, mdNames)
+		if err != nil {
+			return err
+		}
 		if len(placementDecisionLabels) > 0 {
 			for k, v := range placementDecisionLabels {
 				if _, exists := desiredVMG.Labels[k]; exists {
@@ -445,14 +448,17 @@ func GenerateVMGPlacementLabels(ctx context.Context, vmg *vmoprv1.VirtualMachine
 			// TODO: Establish membership via the machine deployment name label
 			if strings.Contains(member.Name, md) {
 				// Get the VM placement information by member status.
+				// Legacy already-placed VM won't have Placement info, just skip it.
 				if member.Placement == nil {
-					return nil, errors.Errorf("VM %s in VMG %s/%s has no placement info. Placement is nil)", member.Name, vmg.Namespace, vmg.Name)
+					log.V(4).Info("VM in VMG has no placement info. Placement is nil", "VM", member.Name, "VMG", vmg.Name, "Namespace", vmg.Namespace)
+					continue
 				}
 
-				// Get the VM placement information by member status.
+				// Skip and try next member if Zone is empty, alrough it should not happen after Placement is not nil.
 				zone := member.Placement.Zone
 				if zone == "" {
-					return nil, errors.Errorf("VM %s in VMG %s/%s has no placement info. Zone is empty", member.Name, vmg.Namespace, vmg.Name)
+					log.V(4).Info("VM in VMG has no placement info. Zone is empty", "VM", member.Name, "VMG", vmg.Name, "Namespace", vmg.Namespace)
+					continue
 				}
 
 				log.Info(fmt.Sprintf("VM %s in VMG %s/%s has been placed in zone %s", member.Name, vmg.Namespace, vmg.Name, zone))


### PR DESCRIPTION

(cherry picked from commit 700c8ae)<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Refine VMG controller when generate per-MD zone labels

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
